### PR TITLE
Now searches entire message for your username

### DIFF
--- a/robin-highlighter.user.js
+++ b/robin-highlighter.user.js
@@ -14,7 +14,7 @@ var username = $("span.user").find("a").first().text().toLowerCase();
 $("#robinChatMessageList").bind("DOMNodeInserted", function() {
     var x = $("#robinChatMessageList .robin-message").last();
     var message = x.find(".robin-message--message");
-    if (message.text().toLowerCase() == username) {
+    if (message.text().toLowerCase().search(username) != -1) {
         message.css("background-color", "yellow");
     }
 });


### PR DESCRIPTION
I thought it was kind of odd for the message to have to be *equal* to the username, so now it searches for an occurrence of the username.

This way, any message that contains your username will be highlighted. It's pretty handy.

If this isn't your intended functionality or you disagree with it, no hard feelings. :)